### PR TITLE
Corrección de Bug que provocaba (previo fallo de la verificación del …

### DIFF
--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -88,11 +88,13 @@ app.post('/google', async(req, res) => {
 
     let googleUser = await verify(token)
         .catch(e => {
-            return res.status(403).json({
+            console.warn("Falló la verificación del token de Google")
+            res.status(403).json({
                 ok: false,
                 err: e
             });
         });
+    if(!googleUser) return;
 
 
     Usuario.findOne({ email: googleUser.email }, (err, usuarioDB) => {


### PR DESCRIPTION
…token de Google) un error del tipo `ERR_HTTP_HEADERS_SENT`

Reproducirlo:

Enviamos un token incorrecto de google a la API REST: `POST`: `{{url}}/google`

Obtenemos el error: `code: 'ERR_HTTP_HEADERS_SENT'`. Por modificar el header, el body y posteriormente (más adelante por no interrumpirse el script) se vuelve a modificar el header y el body.

Concretamente, si la verificación del token de google falla, continua la ejecución hasta la [línea 145](https://github.com/Klerith/node-restserver-curso/blob/8ed4b201f570f7979547c3cbb65d71c70ec26114/server/routes/login.js#L145)